### PR TITLE
fix: auth cookie deleted on log out.

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -30,6 +30,7 @@ export class AuthService {
     let cookieString = 'auth-token=' + token + ';path=/;expires=' + expires;
     if(domain) {
       cookieString += ';domain=' + domain;
+      localStorage.setItem('auth-domain', domain);
     }
 
     document.cookie = cookieString;
@@ -38,8 +39,16 @@ export class AuthService {
   }
 
   clearTokens() {
+    const domain = localStorage.getItem('auth-domain');
+    let cookieString = 'auth-token=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    if(domain) {
+      cookieString += ';domain=' + domain;
+    }
+
     localStorage.removeItem('auth-token');
-    document.cookie = 'auth-token=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    localStorage.removeItem('auth-domain');
+
+    document.cookie = cookieString;
     this.authToken = undefined;
   }
 


### PR DESCRIPTION
closed onepanelio/core#249 

Notes: 
* you might have to refresh upon logging out to see the cookie deleted in chrome.
* you will have to log out and back in to see the log out work as we now store the domain when you log in.