### PR TITLE
fix: issue where a pausing workspace showed incorrect paused time.

### DIFF
--- a/src/app/clock/clock.component.ts
+++ b/src/app/clock/clock.component.ts
@@ -20,7 +20,6 @@ export class ClockComponent implements OnInit, OnDestroy {
       return;
     }
 
-
     if(typeof(value) === 'string') {
       this._startedAt = new Date(value);
     } else {

--- a/src/app/workspace/workspace-status/workspace-status-bar/workspace-status-bar.component.html
+++ b/src/app/workspace/workspace-status/workspace-status-bar/workspace-status-bar.component.html
@@ -6,8 +6,15 @@
             {{workspace.status.phase | workspacePhaseStatus}}
         </div>
         <app-clock
+                *ngIf="workspace.status.phase == 'Running'"
                 class="ml-2"
                 [startedAt]="workspace.status.startedAt"
+                [durationFormatter]="daysDurationFormatter">
+        </app-clock>
+        <app-clock
+                *ngIf="workspace.status.phase == 'Paused'"
+                class="ml-2"
+                [startedAt]="workspace.status.pausedAt"
                 [durationFormatter]="daysDurationFormatter">
         </app-clock>
     </div>


### PR DESCRIPTION
Also removed timer display for all statuses except running and paused.

closed onepanelio/core#297