### PR TITLE
feat: onepanelio.core.261 template.confirm.leave

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { WorkspaceComponent } from "./workspace/workspace.component";
 import { WorkspaceTemplateListComponent } from "./workspace/workspace-template/workspace-template-list/workspace-template-list.component";
 import { WorkspaceTemplateCreateComponent } from "./workspace/workspace-template/workspace-template-create/workspace-template-create.component";
 import { WorkspaceViewComponent } from "./workspace/workspace-view/workspace-view.component";
+import { CanDeactivateGuard } from "./guards/can-deactivate.guard";
 
 const routes: Routes = [
   {
@@ -66,6 +67,7 @@ const routes: Routes = [
     path: ':namespace/workspace-templates',
     component: WorkspaceTemplateListComponent,
     canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: ':namespace/workspace-templates/create',

--- a/src/app/guards/can-deactivate.guard.spec.ts
+++ b/src/app/guards/can-deactivate.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { CanDeactivateGuard } from './can-deactivate.guard';
+
+describe('CanDeactivateGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CanDeactivateGuard]
+    });
+  });
+
+  it('should ...', inject([CanDeactivateGuard], (guard: CanDeactivateGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/guards/can-deactivate.guard.ts
+++ b/src/app/guards/can-deactivate.guard.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface CanComponentDeactivate {
+  canDeactivate: () => Observable<boolean> | Promise<boolean> | boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate> {
+  canDeactivate(component: CanComponentDeactivate) {
+    return component.canDeactivate ? component.canDeactivate() : true;
+  }
+}

--- a/src/app/manifest-dag-editor/manifest-dag-editor.component.html
+++ b/src/app/manifest-dag-editor/manifest-dag-editor.component.html
@@ -1,4 +1,4 @@
-<app-alert [autoDismiss]="false" [alert]="serverError"></app-alert>
+<app-alert [autoDismiss]="false" [alert]="error"></app-alert>
 <app-alert *ngIf="notification" [autoDismiss]="false" [alert]="notification"></app-alert>
 <div class="op-border hide-overflow mt-3">
     <div class="toolbar bg-toolbar-white w-100 op-border-bottom d-flex flex-row-reverse">

--- a/src/app/manifest-dag-editor/manifest-dag-editor.component.ts
+++ b/src/app/manifest-dag-editor/manifest-dag-editor.component.ts
@@ -20,28 +20,84 @@ export class ManifestDagEditorComponent implements OnInit {
   @ViewChild(AceEditorComponent, {static: false}) aceEditor: AceEditorComponent;
   @ViewChild(DagComponent, {static: false}) dag: DagComponent;
 
+  /**
+   * manifestText is the input, starting text, to put into the editor.
+   */
   @Input() manifestText: string;
-  @Input() serverError: Alert;
-  @Input() notification: Alert;
 
-  showingRender: boolean = true;
-  manifestTextCurrent: string;
-  errorMarkerId;
+  /**
+   * error is any error that should be displayed in the UI.
+   * If not set, nothing is shown.
+   */
+  @Input() error?: Alert;
 
-  parameters = new Array<Parameter>();
+  /**
+   * notification is any notification that should be displayed in the UI.
+   * If not set, nothing is shown.
+   */
+  @Input() notification?: Alert;
 
-
+  /**
+   * rawManifest is the current text in the editor after any change has been made to it.
+   * It is raw in the sense that no modification has been made to it - it's exactly what the user has typed in.
+   */
   rawManifest: string;
-  // Default behavior is to just return itself
+
+  /**
+   * manifestTextCurrent is the current text after it has been modified by the manifestInterceptor.
+   * This is not displayed in the text editor, but it is used to display in displaying the graph.
+   */
+  manifestTextCurrent: string;
+
+  /**
+   * manifestInterceptor is an observable that can be used to modify the manifest. It receives the
+   * text that is currently in the editor and it is expected to return new text. This new text
+   * will be used to display the graph.
+   *
+   * Default behavior is to return the input text.
+   */
   @Input() manifestInterceptor: (manifest: string) => Observable<string> = (manifest => of(manifest));
+
+  /**
+   * manifestTextModified is emitted whenever the manifest text is modified in the text editor.
+   * It sends the raw text that is currently in the editor.
+   *
+   * Note that this will fire before the manifestInterceptor is called and even if the manfiest interceptor
+   * generates an error.
+   */
+  @Output() manifestTextModified = new EventEmitter<string>();
+
+  /**
+   * showingRender determines if we are showing the graph preview or the parameters preview.
+   * If true, we are showing the graph preview.
+   * If false, we are showing the parameters preview.
+   */
+  showingRender = true;
+
+  /**
+   * errorMarkerId is a reference to an error marked in the text editor (AceEditor), used to clear the error.
+   * It set, we are displaying an error in the editor.
+   */
+  errorMarkerId?: any;
+
+  /**
+   * parameters are the input parameters parsed from the manifest.
+   */
+  parameters = new Array<Parameter>();
 
   constructor() { }
 
   ngOnInit() {
+    this.rawManifest = this.manifestText;
   }
 
-  onManifestChange(newManifest: string) {
+  onManifestChange(newManifest: string, emitModified = true) {
     this.rawManifest = newManifest;
+
+    if(emitModified) {
+      this.manifestTextModified.emit(newManifest);
+    }
+
     if(!this.manifestInterceptor) {
       this.onManifestChangeFinalized(newManifest);
     } else {
@@ -50,7 +106,7 @@ export class ManifestDagEditorComponent implements OnInit {
             this.onManifestChangeFinalized(res);
           }, (e: HttpErrorResponse) => {
             setTimeout(() => {
-              this.serverError = {
+              this.error = {
                 message: e.error.error,
                 type: 'danger'
               };
@@ -75,7 +131,7 @@ export class ManifestDagEditorComponent implements OnInit {
       this.dag.display(g);
       this.updateParameters(newManifest);
       setTimeout( () => {
-        this.serverError = null;
+        this.error = null;
       });
     }
     catch (e) {
@@ -87,7 +143,7 @@ export class ManifestDagEditorComponent implements OnInit {
         this.errorMarkerId = this.aceEditor.getEditor().session.addMarker(codeErrorRange, "highlight-error", "fullLine");
 
         setTimeout(() => {
-          this.serverError = {
+          this.error = {
             message: e.reason + " at line: " + line + " column: " + column,
             type: 'danger'
           };

--- a/src/app/workflow-template/workflow-template-create/workflow-template-create.component.ts
+++ b/src/app/workflow-template/workflow-template-create/workflow-template-create.component.ts
@@ -3,7 +3,7 @@ import {
   WorkflowTemplateDetail,
   WorkflowTemplateService
 } from '../workflow-template.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { WorkflowService } from "../../workflow/workflow.service";
 import {
   WorkflowTemplateSelectComponent,
@@ -14,7 +14,6 @@ import { AbstractControl, FormBuilder, FormGroup, Validators } from "@angular/fo
 import { HttpErrorResponse } from "@angular/common/http";
 import * as ace from 'brace';
 import { ClosableSnackComponent } from "../../closable-snack/closable-snack.component";
-import { Alert } from "../../alert/alert";
 import { KeyValue, WorkflowServiceService, WorkflowTemplateServiceService } from "../../../api";
 import { LabelsEditComponent } from "../../labels/labels-edit/labels-edit.component";
 import { ManifestDagEditorComponent } from "../../manifest-dag-editor/manifest-dag-editor.component";
@@ -126,7 +125,7 @@ export class WorkflowTemplateCreateComponent implements OnInit, OnDestroy {
             return;
           }
 
-          this.manifestDagEditor.serverError = {
+          this.manifestDagEditor.error = {
             message: err.error.message,
             type: 'danger',
           };

--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
@@ -54,7 +54,6 @@ export class WorkflowTemplateEditComponent implements OnInit {
     private workflowTemplateService: WorkflowTemplateServiceService,
     private labelService: LabelServiceService,
     private datePipe: DatePipe) {
-
   }
 
   ngOnInit() {
@@ -110,7 +109,6 @@ export class WorkflowTemplateEditComponent implements OnInit {
   }
 
   update() {
-    // @todo display error message if there are duplicates in the labels.
     if(!this.labelEditor.isValid) {
         this.labelEditor.markAllAsDirty();
         return;
@@ -130,7 +128,7 @@ export class WorkflowTemplateEditComponent implements OnInit {
       .subscribe(res => {
           this.appRouter.navigateToWorkflowTemplateView(this.namespace, this.workflowTemplate.uid);
       }, (err: HttpErrorResponse) => {
-        this.manifestDagEditor.serverError = {
+        this.manifestDagEditor.error = {
             message: err.error.message,
             type: 'danger',
         };

--- a/src/app/workspace/workspace-template/workspace-template-create/workspace-template-create.component.html
+++ b/src/app/workspace/workspace-template/workspace-template-create/workspace-template-create.component.html
@@ -10,7 +10,8 @@
         </div>
         <app-manifest-dag-editor
                 [manifestText]="manifest"
-                [manifestInterceptor]="apiManifestInterceptor">
+                [manifestInterceptor]="apiManifestInterceptor"
+                (manifestTextModified)="onManifestTextModified($event)">
         </app-manifest-dag-editor>
         <div class="mt-5">
             <div class="op-h2">Labels</div>

--- a/src/app/workspace/workspace-template/workspace-template-create/workspace-template-create.component.ts
+++ b/src/app/workspace/workspace-template/workspace-template-create/workspace-template-create.component.ts
@@ -23,6 +23,12 @@ export class WorkspaceTemplateCreateComponent implements OnInit {
 
   namespace: string;
 
+  /**
+   * manifestChangedSinceSave keeps track if any changes have been made since save was emitted.
+   * It starts as false since the default template is not important and does not contain any custom user changes.
+   */
+  manifestChangedSinceSave = false;
+
   private defaultManifest = `# Docker containers that are part of the Workspace
 containers:
 - name: http
@@ -50,7 +56,7 @@ routes:
   - destination:
       port:
         number: 80
-# DAG Workflow to be executed once a Workspace action completes
+# DAG Workflow to be executed once a Workspace action completes (optional)
 postExecutionWorkflow:
   entrypoint: main
   templates:
@@ -99,10 +105,12 @@ postExecutionWorkflow:
       setTimeout(() => {
         this.setDefaultManifest();
       }, 100)
-    } else {
-      this.manifest = this.defaultManifest;
-      this.manifestDagEditor.onManifestChange(this.defaultManifest);
+
+      return;
     }
+
+    this.manifest = this.defaultManifest;
+    this.manifestDagEditor.onManifestChange(this.defaultManifest, false);
   }
 
   ngOnInit() {
@@ -142,9 +150,24 @@ postExecutionWorkflow:
     };
 
     this.saveEmitted.emit(body);
+
+    this.manifestChangedSinceSave = false;
   }
 
   setAlert(alert: Alert) {
     this.manifestDagEditor.notification = alert;
+  }
+
+  onManifestTextModified(manifest: string) {
+    // No need to set it again
+    if(this.manifestChangedSinceSave) {
+      return;
+    }
+
+    if(manifest === this.defaultManifest) {
+      return;
+    }
+
+    this.manifestChangedSinceSave = true;
   }
 }

--- a/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.html
+++ b/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.html
@@ -16,7 +16,8 @@
         </div>
         <app-manifest-dag-editor
                 [manifestText]="manifest"
-                [manifestInterceptor]="apiManifestInterceptor">
+                [manifestInterceptor]="apiManifestInterceptor"
+                (manifestTextModified)="onManifestTextModified($event)">
         </app-manifest-dag-editor>
         <div class="mt-5">
             <div class="op-h2">Labels</div>

--- a/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.ts
+++ b/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.ts
@@ -49,6 +49,12 @@ export class WorkspaceTemplateEditComponent implements OnInit {
 
   @Input() loading = false;
 
+  /**
+   * manifestChangedSinceSave keeps track if any changes have been made since save was emitted.
+   * It starts as false since the default template is not important and does not contain any custom user changes.
+   */
+  manifestChangedSinceSave = false;
+
   constructor(
       private formBuilder: FormBuilder,
       private activatedRoute: ActivatedRoute,
@@ -113,6 +119,7 @@ export class WorkspaceTemplateEditComponent implements OnInit {
     };
     
     this.saveEmitted.emit(body);
+    this.manifestChangedSinceSave = false;
   }
 
   onVersionSelected(version: string) {
@@ -131,5 +138,18 @@ export class WorkspaceTemplateEditComponent implements OnInit {
 
   setAlert(alert: Alert) {
     this.manifestDagEditor.notification = alert;
+  }
+
+  onManifestTextModified(manifest: string) {
+    // No need to update it again.
+    if(this.manifestChangedSinceSave) {
+      return;
+    }
+
+    if(manifest === this.manifest) {
+      return;
+    }
+
+    this.manifestChangedSinceSave = true;
   }
 }

--- a/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.ts
+++ b/src/app/workspace/workspace-template/workspace-template-edit/workspace-template-edit.component.ts
@@ -94,6 +94,7 @@ export class WorkspaceTemplateEditComponent implements OnInit {
               this.labels = [];
             }
 
+            this.manifestChangedSinceSave = false;
             this.workspaceTemplateVersions = res.workspaceTemplates;
             this.manifest = res.workspaceTemplates[0].manifest;
             this.manifestDagEditor.onManifestChange(this.manifest);
@@ -147,6 +148,7 @@ export class WorkspaceTemplateEditComponent implements OnInit {
     }
 
     if(manifest === this.manifest) {
+      this.manifestChangedSinceSave = false;
       return;
     }
 

--- a/src/app/workspace/workspace-template/workspace-template-list/workspace-template-list.component.html
+++ b/src/app/workspace/workspace-template/workspace-template-list/workspace-template-list.component.html
@@ -58,14 +58,14 @@
     </mat-paginator>
 
     <app-workspace-template-create
-            *ngIf="showWorkspaceTemplateEditor && selectedTemplate === null"
+            *ngIf="state == 'create'"
             (cancelEmitted)="cancelWorkspaceTemplate()"
             (saveEmitted)="onCreate($event)"
             [loading]="creatingWorkspaceTemplate">
     </app-workspace-template-create>
 
     <app-workspace-template-edit
-        *ngIf="showWorkspaceTemplateEditor && selectedTemplate"
+        *ngIf="state == 'edit'"
         [loading]="workspaceTemplateEditLoading"
         [namespace]="namespace"
         [workspaceTemplate]="selectedTemplate"

--- a/src/app/workspace/workspace-template/workspace-template-list/workspace-template-list.component.ts
+++ b/src/app/workspace/workspace-template/workspace-template-list/workspace-template-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import {
-  CreateWorkspaceBody,
   ListWorkspaceTemplatesResponse,
   WorkspaceServiceService,
   WorkspaceTemplate,
@@ -24,13 +23,23 @@ import {
   ConfirmationDialogComponent,
   ConfirmationDialogData
 } from "../../../confirmation-dialog/confirmation-dialog.component";
+import { CanComponentDeactivate } from "../../../guards/can-deactivate.guard";
+import { Observable } from "rxjs";
+
+/**
+ * WorkspaceTemplateState is a way to keep track of the current state of the component.
+ * * create: we are creating a new workspace template
+ * * edit: we are editing an existing workspace template
+ * * view: we are viewing the workspace templates, but not creating or editing.
+ */
+type WorkspaceTemplateState = 'create' | 'edit' | 'view';
 
 @Component({
   selector: 'app-workspace-template-list',
   templateUrl: './workspace-template-list.component.html',
   styleUrls: ['./workspace-template-list.component.scss']
 })
-export class WorkspaceTemplateListComponent implements OnInit {
+export class WorkspaceTemplateListComponent implements OnInit, CanComponentDeactivate {
   @ViewChild(WorkspaceTemplateCreateComponent, {static: false}) workspaceTemplateCreateEditor: WorkspaceTemplateCreateComponent;
   @ViewChild(WorkspaceTemplateEditComponent, {static: false}) workspaceTemplateEditor: WorkspaceTemplateEditComponent;
 
@@ -55,6 +64,8 @@ export class WorkspaceTemplateListComponent implements OnInit {
   workspaceTemplateEditLoading = false;
   creatingWorkspaceTemplate = false;
 
+  state: WorkspaceTemplateState = 'create';
+
   constructor(
       private appRouter: AppRouter,
       private workspaceTemplateService: WorkspaceTemplateServiceService,
@@ -70,6 +81,47 @@ export class WorkspaceTemplateListComponent implements OnInit {
 
       this.getWorkspaceTemplates();
     });
+  }
+
+  canDeactivate(): Observable<boolean> | Promise<boolean> | boolean {
+    const confirmData: ConfirmationDialogData = {
+      title: 'You have unsaved changes',
+      message: 'You have unsaved changes in your template, leaving will discard them.',
+      confirmText: 'DISCARD CHANGES',
+      type: 'confirm'
+    }
+
+    if(this.state === 'create' && this.workspaceTemplateCreateEditor.manifestChangedSinceSave) {
+      const confirmDialog = this.dialog.open(ConfirmationDialogComponent, {
+        data: confirmData
+      })
+
+      return confirmDialog.afterClosed();
+    } else if(this.state === 'edit' && this.workspaceTemplateEditor.manifestChangedSinceSave) {
+
+
+      const confirmDialog = this.dialog.open(ConfirmationDialogComponent, {
+        data: confirmData
+      })
+
+      return confirmDialog.afterClosed();
+    }
+
+    return true;
+  }
+
+  private updateWorkspaceTemplateState() {
+    if(this.showWorkspaceTemplateEditor && this.selectedTemplate === null) {
+      this.state = 'create';
+      return;
+    }
+
+    if(this.showWorkspaceTemplateEditor && this.selectedTemplate) {
+      this.state = 'edit';
+      return;
+    }
+
+    this.state = 'view';
   }
 
   private setWorkspaceTemplateEditorAlert(alert: Alert) {
@@ -109,16 +161,22 @@ export class WorkspaceTemplateListComponent implements OnInit {
   newWorkspaceTemplate() {
     this.showWorkspaceTemplateEditor = true;
     this.selectedTemplate = null;
+
+    this.updateWorkspaceTemplateState();
   }
 
   selectTemplate(template: WorkspaceTemplate) {
     this.showWorkspaceTemplateEditor = true;
     this.selectedTemplate = template;
+
+    this.updateWorkspaceTemplateState();
   }
 
   cancelWorkspaceTemplate() {
     this.showWorkspaceTemplateEditor = false;
     this.selectedTemplate = null;
+
+    this.updateWorkspaceTemplateState();
   }
 
   onCreate(template: WorkspaceTemplate) {
@@ -227,6 +285,7 @@ export class WorkspaceTemplateListComponent implements OnInit {
     this.showWorkspaceTemplateEditor = false;
     this.selectedTemplate = undefined;
 
+    this.updateWorkspaceTemplateState();
     this.getWorkspaceTemplates();
   }
 }


### PR DESCRIPTION
I add a confirmation dialog when the user leaves the Workspace Template List page and has made changes a workspace template.

**What type of PR is this?**
/kind enhancement

**What this PR does / Why do we need it**
The current text editor for Workspace Templates is small, and if you have long lines, you need to scroll left. With a trackpad I scroll left and sometimes go too far and leave the page, going back, and losing all my changes. This PR helps prevent that by adding a confirmation dialog when you leave.

**Which issue(s) this PR fixes**

Fixes onepanelio/core#261

**Special notes for your reviewer**

Use cases to test

Note: leave means navigate away, you can click the `back to workspaces` in the top left to do so.

- [ ] Create a new template leave - no dialog is expected
- [ ] Create a new template, modify it, leave - dialog is expected
- [ ] Open an existing template, leave - no dialog is expected
- [ ] Open an existing template, modify it, leave - dialog is expected
- [ ] Open an existing template, modify it, switch to another template, leave - no dialog is expected

Note: if you create a template, modify it, undo your changes, we still show a confirmation dialog. The reasoning here is that you did modify it. 

