### PR TITLE
feat: Add confirmation when leaving workflow template create/edit after modified

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,6 +43,7 @@ const routes: Routes = [
     path: ':namespace/workflow-templates/:uid/edit',
     component: WorkflowTemplateEditComponent,
     canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: ':namespace/workflow-templates/:uid',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -32,6 +32,7 @@ const routes: Routes = [
     path: ':namespace/workflow-templates/create',
     component: WorkflowTemplateCreateComponent,
     canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: ':namespace/workflow-templates/:uid/clone',

--- a/src/app/workflow-template/workflow-template-create/workflow-template-create.component.html
+++ b/src/app/workflow-template/workflow-template-create/workflow-template-create.component.html
@@ -19,7 +19,8 @@
         </app-workflow-template-select>
         <app-manifest-dag-editor
                 class="ml-8 flex-grow-1"
-                [manifestText]="manifestText">
+                [manifestText]="manifestText"
+                (manifestTextModified)="onManifestTextModified($event)">
         </app-manifest-dag-editor>
       </div>
       <div class="mt-5">

--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.html
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.html
@@ -24,7 +24,8 @@
       <div class="d-flex">
         <app-manifest-dag-editor
                 class="flex-grow-1"
-                [manifestText]="manifestText">
+                [manifestText]="manifestText"
+                (manifestTextModified)="onManifestTextModified($event)">
         </app-manifest-dag-editor>
       </div>
       <div class="mt-5">

--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
@@ -16,6 +16,13 @@ import {
 } from "../../../api";
 import { ManifestDagEditorComponent } from "../../manifest-dag-editor/manifest-dag-editor.component";
 import { DatePipe } from "@angular/common";
+import { CanComponentDeactivate } from "../../guards/can-deactivate.guard";
+import { Observable } from "rxjs";
+import {
+    ConfirmationDialogComponent,
+    ConfirmationDialogData
+} from "../../confirmation-dialog/confirmation-dialog.component";
+import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 
 @Component({
   selector: 'app-workflow-template-edit',
@@ -23,7 +30,7 @@ import { DatePipe } from "@angular/common";
   styleUrls: ['./workflow-template-edit.component.scss'],
   providers: [DatePipe]
 })
-export class WorkflowTemplateEditComponent implements OnInit {
+export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeactivate {
   @ViewChild(ManifestDagEditorComponent, {static: false}) manifestDagEditor: ManifestDagEditorComponent;
   @ViewChild(LabelsEditComponent, {static: false}) labelEditor: LabelsEditComponent;
 
@@ -39,6 +46,11 @@ export class WorkflowTemplateEditComponent implements OnInit {
   // This is what we display in the side menu
   workflowTemplateListItems = new Array<WorkflowTemplateSelectItem>();
 
+  /**
+   * manifestChanged keeps track if any changes have been made since the editor was opened.
+   */
+  manifestChanged = false;
+
   get workflowTemplate(): WorkflowTemplate {
     return this._workflowTemplate;
   }
@@ -53,7 +65,8 @@ export class WorkflowTemplateEditComponent implements OnInit {
     private activatedRoute: ActivatedRoute,
     private workflowTemplateService: WorkflowTemplateServiceService,
     private labelService: LabelServiceService,
-    private datePipe: DatePipe) {
+    private datePipe: DatePipe,
+    private dialogRef: MatDialog) {
   }
 
   ngOnInit() {
@@ -64,6 +77,25 @@ export class WorkflowTemplateEditComponent implements OnInit {
       this.getWorkflowTemplate();
       this.getWorkflowTemplateVersions();
     });
+  }
+
+  canDeactivate(): Observable<boolean> | Promise<boolean> | boolean {
+      if(!this.manifestChanged) {
+          return true;
+      }
+      
+      const confirmData: ConfirmationDialogData = {
+          title: 'You have unsaved changes',
+          message: 'You have unsaved changes in your template, leaving will discard them.',
+          confirmText: 'DISCARD CHANGES',
+          type: 'confirm'
+      }
+
+      const confirmDialog = this.dialogRef.open(ConfirmationDialogComponent, {
+          data: confirmData
+      })
+
+      return confirmDialog.afterClosed();
   }
 
   getWorkflowTemplate() {
@@ -164,5 +196,19 @@ export class WorkflowTemplateEditComponent implements OnInit {
 
       this.manifestText = version.manifest;
       this.getLabels(version.version);
+  }
+
+  onManifestTextModified(manifest: string) {
+      // No need to update the change status again
+      if(this.manifestChanged) {
+          return;
+      }
+
+      if(manifest === this.manifestText) {
+          this.manifestChanged = false;
+          return;
+      }
+
+      this.manifestChanged = true;
   }
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does**:

Adds a confirmation dialog when the user leaves a Workflow template create/edit page after changes have been made in the template editor.

Fixes onepanelio/core#311

**Special notes for your reviewer**:

None