### PR TITLE
fix: confirmation dialog when trying to edit or save a workflow template

### DIFF
--- a/src/app/workflow-template/workflow-template-create/workflow-template-create.component.ts
+++ b/src/app/workflow-template/workflow-template-create/workflow-template-create.component.ts
@@ -103,6 +103,8 @@ export class WorkflowTemplateCreateComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.manifestChanged = false;
+
     this.state = 'creating';
     const manifestText = this.manifestDagEditor.manifestTextCurrent;
     this.workflowTemplateServiceService

--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
@@ -109,6 +109,8 @@ export class WorkflowTemplateEditComponent implements OnInit {
   }
 
   update() {
+    this.manifestChanged = false;
+
     if(!this.labelEditor.isValid) {
         this.labelEditor.markAllAsDirty();
         return;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does**:

Fixes an issue where a Confirmation Dialog appears when you edit an existing Workflow Template or save a newly created Workflow Template.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#319

**Special notes for your reviewer**:

To reproduce the issue in other branches

**Creating a Workflow Template**

If you select a template, make sure to modify it. Otherwise, the system doesn't see any modifications so lets you save without a dialog.

**Editing a Workflow Template**

Make sure to modify the template then hit save.