### PR TITLE
feat: loading indicator when updating an edited workflow template

### DIFF
--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.html
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.html
@@ -34,9 +34,10 @@
       </div>
       <div class="mt-5 d-flex justify-content-between">
         <button mat-button class="font-medium-gray cancel-button" (click)="cancel()">CANCEL</button>
-        <div>
-          <button mat-flat-button color="accent" class="op-rounded op-button border-secondary" (click)="update()">Save</button>
-        </div>
+        <app-button [loading]="saving" (click)="update()">
+          Save
+          <span class="loading">Saving</span>
+        </app-button>
       </div>
     </div>
   </div>

--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
@@ -51,6 +51,11 @@ export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeacti
    */
   manifestChanged = false;
 
+  /**
+   * saving is true if the editor is currently saving the data and false otherwise.
+   */
+  saving = false;
+
   get workflowTemplate(): WorkflowTemplate {
     return this._workflowTemplate;
   }
@@ -148,6 +153,8 @@ export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeacti
 
     const manifestText = this.manifestDagEditor.manifestTextCurrent;
 
+    this.saving = true;
+
     this.workflowTemplateService
       .createWorkflowTemplateVersion(
         this.namespace,
@@ -159,11 +166,14 @@ export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeacti
         })
       .subscribe(res => {
           this.appRouter.navigateToWorkflowTemplateView(this.namespace, this.workflowTemplate.uid);
+          this.saving = false;
       }, (err: HttpErrorResponse) => {
         this.manifestDagEditor.error = {
             message: err.error.message,
             type: 'danger',
         };
+
+        this.saving = false;
       });
   }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does**:

Add a loading indicator to the saving button in Workflow Template Edit page when it is saving.
This helps the user know something is happening and prevents multiple clicks.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#320

**Special notes for your reviewer**:

None.