### PR TITLE
fix: remove overflow scroll, which is giving the scroll bars.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar *ngIf="!loggingIn && showNavigationBar" color="primary" class="app-toolbar scroll-overflow">
+<mat-toolbar *ngIf="!loggingIn && showNavigationBar" color="primary" class="app-toolbar">
   <a class="image-link" [routerLink]="['/']" matTooltip="Version: {{version}}"><img src="/assets/images/onepanel-logo-blue-white.png"/></a>
   <div class="d-flex font-roboto dropdown bg-light-gray align-items-center ml-5" (click)="onFormFieldClick()">
     <i class="far fa-sticky-note color-primary"></i>


### PR DESCRIPTION
**What this PR does**:

Removes the navigation header scroll bars in linux chrome.

**Which issue(s) this PR fixes**:
Fixes onepanelio/core#337

**Special notes for your reviewer**:
