### PR TITLE
fix: Show different messages and perform different actions depending on auth errors

### DIFF
--- a/src/app/http-interceptors/permission-interceptor.ts
+++ b/src/app/http-interceptors/permission-interceptor.ts
@@ -27,15 +27,10 @@ export class PermissionInterceptor implements HttpInterceptor {
                 const currentUrl = req.url;
                 const isOnPermittedUrl = pageUrl === '/login' || currentUrl === '/login' || currentUrl.indexOf('/apis/v1beta1/auth') > -1;
 
-                const errorStatus = error.status === 401 || error.status === 403;
-                // Display a login alert on a permissions related (401/403) error.
+                // Display a login alerts on a permissions related (401/403) error.
                 // If we're already displaying such an alert, don't display it again.
-                if(errorStatus && !this.snackbarRef && !isOnPermittedUrl) {
-                    let message = 'Not logged in';
-                    if(error.status === 403) {
-                        message = 'Unauthorized'
-                    }
-
+                if(error.status === 401 && !this.snackbarRef && !isOnPermittedUrl) {
+                    let message = 'You are not logged in';
                     this.snackbarRef = this.snackbar.open(message, 'Login');
                     this.snackbarRef.afterDismissed()
                         .subscribe(res => {
@@ -45,6 +40,14 @@ export class PermissionInterceptor implements HttpInterceptor {
                                     'referer': this.router.url
                                     }});
                             }
+                        })
+                }
+                if(error.status === 403 && !this.snackbarRef && !isOnPermittedUrl) {
+                    let message = 'Unauthorized';
+                    this.snackbarRef = this.snackbar.open(message, 'Close');
+                    this.snackbarRef.afterDismissed()
+                        .subscribe(() => {
+                            this.snackbarRef = null;
                         })
                 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Show different messages and actions depending on auth errors:
- On 401, displays "You are not logged in" with a "Login" button that takes user to login page
- On 403, displays "Unauthorized" with a "Close" button.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->

**Special notes for your reviewer**:
