### PR TITLE
fix: added error message for workspace creation if error is not a 409

### DIFF
--- a/src/app/workspace/workspace-execute-dialog/workspace-execute-dialog.component.ts
+++ b/src/app/workspace/workspace-execute-dialog/workspace-execute-dialog.component.ts
@@ -114,7 +114,8 @@ export class WorkspaceExecuteDialogComponent implements OnInit {
             };
           } else {
             this.alert = new Alert({
-              message: 'Unable to create workspace',
+              title: 'Unable to create workspace',
+              message: err.error.error,
               type: 'danger'
             });
           }


### PR DESCRIPTION
**What this PR does**:

Adds an error message for workspace creation if if the error is not a 409

Fixes onepanelio/core#361

**Special notes for your reviewer**:

Try a bad name like `600s` and the error message should show up.
This PR should be tested along with https://github.com/onepanelio/core/pull/370
