### PR TITLE
fix: disable terminate button while workspaces are pausing or launching

### DIFF
--- a/src/app/workspace/workspace-status/workspace-status-bar/workspace-status-bar.component.html
+++ b/src/app/workspace/workspace-status/workspace-status-bar/workspace-status-bar.component.html
@@ -29,7 +29,8 @@
         </button>
         <button *ngIf="canDelete" mat-button
                 class="font-weight-bold font-size-regular color-danger"
-                (click)="onDelete(workspace)">
+                (click)="onDelete(workspace)"
+                [disabled]="workspace.status.phase === 'Launching' || workspace.status.phase === 'Pausing'">
             <mat-icon class="vertical-baseline" [fontSet]="'far'" [fontIcon]="'fa-trash-alt'"></mat-icon>
             DELETE WORKSPACE
         </button>

--- a/src/app/workspace/workspace.component.html
+++ b/src/app/workspace/workspace.component.html
@@ -139,7 +139,7 @@
                 <i class="far fa-play-circle mr-1 workspace-menu-icon"></i>
                 Resume
             </button>
-            <button *ngIf="workspacePermissions.get(workspace.uid).delete" mat-menu-item (click)="onDelete(workspace)" [disabled]="workspace.status.phase === 'Terminating'">
+            <button *ngIf="workspacePermissions.get(workspace.uid).delete" mat-menu-item (click)="onDelete(workspace)" [disabled]="workspace.status.phase === 'Terminating' || workspace.status.phase === 'Launching' || workspace.status.phase === 'Pausing'">
                 <i class="fas fa-trash mr-1 workspace-menu-icon"></i>
                 Terminate
             </button>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -483,7 +483,7 @@ mat-spinner.color-danger {
 }
 
 button {
-  &.color-danger[disabled=true]  {
+  &.color-danger[disabled=true] {
     color: rgba(0, 0, 0, 0.26) !important;
   }
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -481,3 +481,9 @@ mat-spinner.color-danger {
     }
   }
 }
+
+button {
+  &.color-danger[disabled=true]  {
+    color: rgba(0, 0, 0, 0.26) !important;
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Disable terminate button while workspaces are pausing or launching in workspace list and view pages.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#322

**Special notes for your reviewer**:
