### PR TITLE
fix: missing edit labels button in workflow execution

### DIFF
--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -197,7 +197,15 @@ export class WorkflowComponent implements OnInit, OnDestroy {
     const canCreate$ = this.authService.isAuthorized({
       namespace: this.namespace,
       verb: 'create',
-      resource: 'workspaces',
+      resource: 'workflows',
+      resourceName: workflowExecution.uid,
+      group: 'onepanel.io',
+    });
+
+    const canUpdate$ = this.authService.isAuthorized({
+      namespace: this.namespace,
+      verb: 'update',
+      resource: 'workflows',
       resourceName: workflowExecution.uid,
       group: 'onepanel.io',
     });
@@ -205,20 +213,22 @@ export class WorkflowComponent implements OnInit, OnDestroy {
     const canDelete$ = this.authService.isAuthorized({
       namespace: this.namespace,
       verb: 'delete',
-      resource: 'workspaces',
+      resource: 'workflows',
       resourceName: workflowExecution.uid,
       group: 'onepanel.io',
     });
 
-    combineLatest([canCreate$, canDelete$])
+    combineLatest([canCreate$, canUpdate$, canDelete$])
         .pipe(
-            map(([canCreate$, canDelete$]) => ({
+            map(([canCreate$, canUpdate$, canDelete$]) => ({
               canCreate: canCreate$,
+              canUpdate: canUpdate$,
               canDelete: canDelete$
             }))
         ).subscribe(res => {
+          this.permissions.create = res.canCreate.authorized;
+          this.permissions.update = res.canUpdate.authorized;
           this.permissions.delete = res.canDelete.authorized;
-            this.permissions.create = res.canCreate.authorized;
         })
   }
 


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where edit labels button did not show up in workflow executions.
This was due to a missing update permissions request.
This also fixes an issue where the permissions request were for workspaces and not workflows.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#403

**Special notes for your reviewer**:
