### PR TITLE
fix: template status bars had failed and terminated swapped visually

### DIFF
--- a/src/app/workflow-template/workflow-template-status/workflow-template-status.component.html
+++ b/src/app/workflow-template/workflow-template-status/workflow-template-status.component.html
@@ -6,11 +6,11 @@
         <div *ngIf="values.length > 1">
             <span class="font-weight-bold">{{values[1]}}</span> completed
         </div>
-        <div *ngIf="values.length > 3" class="ml-3">
-            <span class="font-weight-bold">{{values[3]}}</span> terminated
-        </div>
         <div *ngIf="values.length > 2" class="ml-3">
             <span class="font-weight-bold">{{values[2]}}</span> failed
+        </div>
+        <div *ngIf="values.length > 3" class="ml-3">
+            <span class="font-weight-bold">{{values[3]}}</span> terminated
         </div>
     </div>
     <div>


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where the status bars for Workflow Template page had failed and terminated swapped.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#408

**Special notes for your reviewer**:

To test this easier, you can modify this line

https://github.com/onepanelio/core-ui/blob/master/src/app/workflow-template/workflow-template-status/workflow-template-status.component.ts#L75

change it to 
```
this.values = [5, 6, 7, 8];
```

this allows you to see what the different bars would look like
