### PR TITLE
fix: labels failed to load for earlier workflow template versions

### DIFF
--- a/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
+++ b/src/app/workflow-template/workflow-template-edit/workflow-template-edit.component.ts
@@ -183,23 +183,6 @@ export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeacti
     this.appRouter.navigateToWorkflowTemplateView(this.namespace, this.workflowTemplate.uid);
   }
 
-  getLabels(version: string|null = null) {
-      const templateVersion = this.workflowTemplateVersions.find(wft => wft.version === version);
-      if(!templateVersion) {
-          return;
-      }
-
-      this.labelService.getLabels(this.namespace, 'workflow_template_version', templateVersion.uid)
-        .subscribe(res => {
-            if(!res.labels) {
-                this.labels = [];
-                return;
-            }
-
-            this.labels = res.labels;
-        })
-  }
-
   onVersionSelected(selected: string) {
       const version = this.workflowTemplateVersions.find(wft => wft.version === selected);
       if(!version) {
@@ -207,7 +190,11 @@ export class WorkflowTemplateEditComponent implements OnInit, CanComponentDeacti
       }
 
       this.manifestText = version.manifest;
-      this.getLabels(version.version);
+      if(version.labels) {
+          this.labels = version.labels;
+      } else {
+          this.labels = [];
+      }
   }
 
   onManifestTextModified(manifest: string) {


### PR DESCRIPTION
**What this PR does**:

* Fixes an issue where selecting previous versions of a workflow template failed to load the labels.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#435

**Special notes for your reviewer**:
