### PR TITLE
fix: failing to load a workflow template is now indicated in UI

### DIFF
--- a/src/app/workflow-template/workflow-template-view/workflow-template-view.component.html
+++ b/src/app/workflow-template/workflow-template-view/workflow-template-view.component.html
@@ -22,6 +22,9 @@
         </mat-spinner>
         <span class="font-roboto-bold font-weight-bold font-size-large color-medium-gray ml-3">Loading Workflow template</span>
       </div>
+      <div *ngIf="state === 'failed-to-load'" class="d-flex align-items-center justify-content-center">
+        <span class="font-roboto-bold font-weight-bold font-size-large color-medium-gray ml-3">Failed to load Workflow template</span>
+      </div>
       <div *ngIf="workflowTemplate">
         <div class="header">
           <div class="title">{{workflowTemplate.name}}</div>

--- a/src/app/workflow-template/workflow-template-view/workflow-template-view.component.ts
+++ b/src/app/workflow-template/workflow-template-view/workflow-template-view.component.ts
@@ -29,7 +29,7 @@ export class Pagination {
   pageSize: number = 15;
 }
 
-type WorkflowTemplateViewState = 'initialization' | 'new' | 'executing';
+type WorkflowTemplateViewState = 'initialization' | 'new' | 'executing' | 'failed-to-load';
 type WorkflowTemplateViewExecutionsState = 'initialization' | 'new' | 'loading';
 
 @Component({
@@ -160,6 +160,8 @@ export class WorkflowTemplateViewComponent implements OnInit {
         this.workflowTemplate = res;
         this.labels = res.labels;
         this.state = 'new';
+      }, err => {
+        this.state = 'failed-to-load';
       });
   }
 


### PR DESCRIPTION
**What this PR does**:

Failing to load a workflow template when viewing one now shows a corresponding UI. Before, it just showed a never ending loading indicator.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#451

**Special notes for your reviewer**:
