### PR TITLE
feat: confirm workspace delete and increase default textarea size

### DIFF
--- a/src/app/fields/textarea/textarea.component.html
+++ b/src/app/fields/textarea/textarea.component.html
@@ -7,7 +7,7 @@
             {{data.name}}
         </ng-container>
     </mat-label>
-    <textarea matInput [(ngModel)]="data.value" [formControl]="textAreaControl"></textarea>
+    <textarea matInput [(ngModel)]="data.value" [formControl]="textAreaControl" rows="5"></textarea>
     <mat-hint *ngIf="data.hint" [innerHtml]="data.hint"></mat-hint>
     <mat-error>Must not be blank</mat-error>
 </mat-form-field>


### PR DESCRIPTION
**What this PR does**:

* Adds a confirmation dialog to deleting a workspace from the workspace list
* Increases the default textarea size to 5 rows

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#504

**Special notes for your reviewer**:
