### PR TITLE
fix: push "dev" image and not "latest" when master is pushed to

### DIFF
--- a/.github/workflows/push_master_branch.yaml
+++ b/.github/workflows/push_master_branch.yaml
@@ -11,6 +11,7 @@ jobs:
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
+          tags: "dev"
           name: onepanel/core-ui
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
**What this PR does**:

Modifies the github action when master is pushed to so it pushes up a "dev" image and not a "latest" image.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:
