### PR TITLE
fix: issue where workflow sorting didn't always work

### DIFF
--- a/src/app/workflow/workflow-executions/workflow-executions.component.ts
+++ b/src/app/workflow/workflow-executions/workflow-executions.component.ts
@@ -25,8 +25,10 @@ export class WorkflowExecutionsComponent implements OnInit, OnDestroy {
   @Input() page = 0;
   @Input() pageSize = 15;
   @Input() displayedColumns = ['name', 'status', 'createdAt', 'start', 'end', 'template', 'spacer', 'actions'];
-  @Input() sortOrder = 'startedAt,desc';
+  @Input() sortOrder = 'createdAt,desc';
   @Input() showSystem = false;
+
+  private previousSortOrder = 'createdAt,desc';
 
   // tslint:disable-next-line:variable-name
   private _phase?: WorkflowExecutionPhase;
@@ -116,7 +118,8 @@ export class WorkflowExecutionsComponent implements OnInit, OnDestroy {
   private updateWorkflowExecutionList(workflowExecutions: WorkflowExecution[]) {
     // If the lengths are different, we have new workflows or deleted workflows,
     // so just update the entire list.
-    if (this.workflows.length !== workflowExecutions.length) {
+    if ((this.workflows.length !== workflowExecutions.length) ||
+        (this.previousSortOrder !== this.sortOrder)) {
       this.workflows = workflowExecutions;
       return;
     }
@@ -204,11 +207,12 @@ export class WorkflowExecutionsComponent implements OnInit, OnDestroy {
         break;
     }
 
+    this.previousSortOrder = this.sortOrder;
     this.sortOrder = `${field},${event.direction}`;
 
     // default sort order.
     if (event.direction === '') {
-      this.sortOrder = `startedAt,desc`;
+      this.sortOrder = `createdAt,desc`;
     }
 
     this.getWorkflows();


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where sorting workflows when you have <= the number displayed in the list didn't do anything.
Also changes default sort to be createdAt, which is what is displayed in UI.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:
