### PR TITLE
fix: issue where switching to a not-launched node displayed old artifacts

### DIFF
--- a/src/app/node-info/node-info.component.ts
+++ b/src/app/node-info/node-info.component.ts
@@ -104,6 +104,8 @@ export class NodeInfoComponent implements OnInit, OnDestroy {
 
     this.inputParameters = [];
     this.inputArtifacts = [];
+    this.outputParameters = [];
+    this.outputArtifacts = [];
 
     this.previousNodeStatus = this.node;
     this.node = node;
@@ -216,11 +218,6 @@ export class NodeInfoComponent implements OnInit, OnDestroy {
         name: this.name,
         workflowService: this.workflowServiceService,
       });
-
-      // const parts = directory.split('/');
-      // if (parts.length > 0) {
-      //   fileNavigator.displayRootPath = parts[parts.length - 1];
-      // }
 
       // Check if there are any files at all. If there isn't, don't display the file browser.
       this.fileLoaderSubscriptions[directory] = fileNavigator.filesChanged.subscribe(() => {


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where switching to a node that had not yet launched displayed the old artifacts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
