### PR TITLE
fix: no domain for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docker-push:
 	docker push onepanel/core-ui:$(COMMIT_HASH)
 
 docker-custom:
-	docker build -t onepanel-core-ui .
+	docker build -t onepanel-core-ui . --build-arg VERSION=$(VERSION)
 	docker tag onepanel-core-ui:latest onepanel/core-ui:$(TAG)
 	docker push onepanel/core-ui:$(TAG)
 

--- a/angular.json
+++ b/angular.json
@@ -76,7 +76,7 @@
               "browserTarget": "onepanel-core-ui:build:production"
             },
             "local": {
-              "browserTarget": "onepanel-core-ui:build:local",
+              "browserTarget": "onepanel-core-ui:build:local"
             }
           }
         },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <app-navbar
   *ngIf="!loggingIn && showNavigationBar"
+  [version]="version"
   [activeUrl]="activeUrl"
   (logout)="logout()"
   (namespaceClick)="onFormFieldClick()">

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -45,6 +46,12 @@ export class AuthService {
   }
 
   setLogin(username: string, token: string, domain?: string) {
+    // When using a local environment, we don't want the domain set as we could be connected to a live running server
+    // on it's domain. This causes issues with cookies, so we don't set a domain when running locally.
+    if (environment.type === 'local') {
+      domain = undefined;
+    }
+
     localStorage.setItem('auth-token', token);
     localStorage.setItem('auth-username', username);
     if (domain) {

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -72,22 +72,22 @@ export class LoginComponent implements OnInit {
             token: this.tokenInput.value,
             username: this.usernameInput.value
         }).subscribe(res => {
-                this.authService.setLogin(this.usernameInput.value, res.token, res.domain);
+            this.authService.setLogin(this.usernameInput.value, res.token, res.domain);
 
-                this.namespaceTracker.getNamespaces();
+            this.namespaceTracker.getNamespaces();
 
-                if (this.authService.redirectUrl) {
-                    this.appRouter.navigateByUrl(this.authService.redirectUrl);
-                    this.authService.redirectUrl = null;
-                    this.loggingIn = false;
-                    return;
-                }
-
-                this.appRouter.navigateToHomePage();
+            if (this.authService.redirectUrl) {
+                this.appRouter.navigateByUrl(this.authService.redirectUrl);
+                this.authService.redirectUrl = null;
                 this.loggingIn = false;
-            }, err => {
-                this.tokenInput.setErrors({error: 'Invalid token'});
-                this.loggingIn = false;
-            });
+                return;
+            }
+
+            this.appRouter.navigateToHomePage();
+            this.loggingIn = false;
+        }, err => {
+            this.tokenInput.setErrors({error: 'Invalid token'});
+            this.loggingIn = false;
+        });
     }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
+  type: 'production',
   baseUrl: '<baseUrl>',
   baseWsUrl: '<baseWSurl>',
-  version: "1.0.0"
+  version: '1.0.0'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,9 +4,10 @@
 
 export const environment = {
   production: false,
+  type: 'local',
   baseUrl: 'http://localhost:8888',
   baseWsUrl: 'ws://localhost:8888',
-  version: "1.0.0"
+  version: 'development'
 };
 
 /*
@@ -16,4 +17,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where domain was being set during local development. This caused issues when you were pointing at a live deployment.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#685

**Special notes for your reviewer**:

You can test this by running `ng serve` and logging out and then in. The domain should be correct for cookies.

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
