### PR TITLE
fix: view overflow on workflows/workspaces lists

### DIFF
--- a/src/app/dashboard/dashboard-workflow/dashboard-workflow.component.scss
+++ b/src/app/dashboard/dashboard-workflow/dashboard-workflow.component.scss
@@ -14,13 +14,13 @@
     margin-top: 15px;
   }
 
-  @media screen and (max-width: 1900px) {
+  @media screen and (max-width: 1940px) {
     /deep/ .cdk-column-template {
       display: none;
     }
   }
 
-  @media screen and (max-width: 1600px) {
+  @media screen and (max-width: 1610px) {
     /deep/ .cdk-column-end {
       display: none;
     }
@@ -32,8 +32,14 @@
     }
   }
 
-  @media screen and (max-width: 1100px) {
+  @media screen and (max-width: 1150px) {
     /deep/ .cdk-column-createdAt {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 950px) {
+    /deep/ .cdk-column-status {
       display: none;
     }
   }

--- a/src/app/dashboard/dashboard-workspace/dashboard-workspace.component.scss
+++ b/src/app/dashboard/dashboard-workspace/dashboard-workspace.component.scss
@@ -72,7 +72,7 @@
     }
   }
 
-  @media screen and (max-width: 1500px) {
+  @media screen and (max-width: 1570px) {
     /deep/ .cdk-column-timestamp-status {
       display: none;
     }
@@ -90,8 +90,14 @@
     }
   }
 
-  @media screen and (max-width: 1100px) {
+  @media screen and (max-width: 1320px) {
     /deep/ .cdk-column-createdAt {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 1060px) {
+    /deep/ .cdk-column-template {
       display: none;
     }
   }

--- a/src/app/navbar/navbar.component.scss
+++ b/src/app/navbar/navbar.component.scss
@@ -35,7 +35,7 @@
     padding: 0 20px;
     height: 43px;
     position: relative;
-    bottom: -3px;
+    bottom: -4px;
     
     &:hover {
       cursor: pointer;

--- a/src/app/workflow/workflow.component.scss
+++ b/src/app/workflow/workflow.component.scss
@@ -1,6 +1,6 @@
 .workflow {
   /deep/ .workflow-executions-list {
-    @media screen and (max-width: 1500px) {
+    @media screen and (max-width: 1580px) {
       /deep/ .cdk-column-template {
         display: none;
       }

--- a/src/app/workspace/workspace-list/workspace-list.component.scss
+++ b/src/app/workspace/workspace-list/workspace-list.component.scss
@@ -46,4 +46,16 @@
       color: $darkest-gray;
     }
   }
+
+  @media screen and (max-width: 1200px) {
+    /deep/ .cdk-column-timestamp-status {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 950px) {
+    /deep/ .cdk-column-createdAt {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
**What this PR does**:

Fixes overflow issues where the "View" button on workflow and workspaces lists would overflow to the next line on certain screen sizes. This is for both the dashboard and the individual listing pages.

This also fixes an issue where the selected namespace section of the navbar would not be flush with the bottom on bigger screen heights.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#717

**Special notes for your reviewer**:

You can test this by using chrome's device toolbar and making it have more/less width. Before this fix the "View" button would overflow on certain widths.

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
