### PR TITLE
feat: Add support to scroll into view a linked Workflow task

### DIFF
--- a/src/app/dag/dag.component.ts
+++ b/src/app/dag/dag.component.ts
@@ -10,7 +10,7 @@ import {
 import * as d3 from 'd3';
 import * as dagre from 'dagre';
 import * as dagreD3 from 'dagre-d3';
-import { NodeInfo } from "../node/node.service";
+import { NodeInfo } from '../node/node.service';
 
 export interface DagClickEvent {
   nodeId: string;
@@ -77,7 +77,7 @@ export class DagComponent implements OnInit {
       node.append(this.bufferInner.select('.output').node().cloneNode(true));
 
       // Persist the node selection.
-      if(this.selectedNodeId) {
+      if (this.selectedNodeId) {
         try {
           this.svg.select(`#${this.selectedNodeId}`).classed('selected', true);
         } catch (e) {
@@ -103,6 +103,37 @@ export class DagComponent implements OnInit {
         info: nodeData.info,
       });
     });
+  }
+
+  /**
+   * Selects a node given it's id.
+   * No nodeClicked event is emitted.
+   */
+  selectNode(nodeId: string, scrollIntoView: boolean = true) {
+    this.selectedNodeId = nodeId;
+    this.svg.selectAll('g.node.selected').classed('selected', false);
+    const selection = this.svg.select(`#${this.selectedNodeId}`).classed('selected', true);
+
+    if (!scrollIntoView) {
+      return;
+    }
+
+    const groups = selection._groups;
+    if (groups.length !== 1) {
+      return;
+    }
+
+    const groupItems = groups[0];
+    if (groupItems.length !== 1) {
+      return;
+    }
+
+    if (!groupItems[0].id) {
+      return;
+    }
+
+    const id = groupItems[0].id;
+    document.getElementById(id).scrollIntoView(true);
   }
 
   clear() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

The workflow view page now adds a node query parameter to the url when a node is selected.
Also, if you take a url with a node query parameter, the page will scroll that node into view and open the node info panel with that node.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#768

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
