### PR TITLE
fix: incorrect permissions requested for workflow create

### DIFF
--- a/src/app/auth/models.ts
+++ b/src/app/auth/models.ts
@@ -1,10 +1,10 @@
 export interface AvailablePermissions {
-    create?: boolean,
-    get?: boolean,
-    watch?: boolean
-    list?: boolean
-    delete?: boolean,
-    update?: boolean,
+    create?: boolean;
+    get?: boolean;
+    watch?: boolean;
+    list?: boolean;
+    delete?: boolean;
+    update?: boolean;
 }
 
 export class Permissions {

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -114,13 +114,7 @@ export class WorkflowComponent implements OnInit {
 
   private checkPermissions(namespace: string) {
     this.permissionService
-        .getWorkflowPermissions(namespace, '', 'list')
-        .subscribe(res => {
-          this.workflowPermissions = res;
-        });
-
-    this.permissionService
-        .getWorkspacePermissions(namespace, '', 'create')
+        .getWorkflowPermissions(namespace, '', 'create', 'list')
         .subscribe(res => {
           this.workflowPermissions = res;
         });


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where workflow execute button was sometimes hidden.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#825

**Special notes for your reviewer**:

Before the `create` permission was checked for `workspaces` I combined it into `workflows`. 

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
