### PR TITLE
feat: add additional error handling for login page

### DIFF
--- a/src/app/alert/alert.service.ts
+++ b/src/app/alert/alert.service.ts
@@ -21,6 +21,14 @@ export class AlertService {
     this.alertReceived.emit();
   }
 
+  public danger(message: string, title?: string) {
+    this.storeAlert(new Alert({
+      type: 'danger',
+      message,
+      title
+    }));
+  }
+
   public peekLocalAlerts(): Array<Alert> {
     let alertsRaw = localStorage.getItem(AlertService.identifier);
 

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -1,3 +1,4 @@
+<app-alert-panel class="login-page-alerts"></app-alert-panel>
 <div class="d-flex justify-content-center align-items-center login">
     <div class="op-info-box content">
         <div class="font-proxima-bold font-size-larger color-primary">Log in</div>

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -1,3 +1,10 @@
+.login-page-alerts {
+  position: fixed;
+  width: calc(100vw - 80px);
+  left: 40px;
+  top: 10px;
+}
+
 .login {
   height: 100vh;
 

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -5,6 +5,8 @@ import { AuthServiceService } from '../../../api';
 import { NamespaceTracker } from '../../namespace/namespace-tracker.service';
 import { AppRouter } from '../../router/app-router.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AlertService } from '../../alert/alert.service';
 
 @Component({
     selector: 'app-login',
@@ -18,6 +20,7 @@ export class LoginComponent implements OnInit {
     loggingIn = false;
 
     constructor(
+        private alertService: AlertService,
         private snackBar: MatSnackBar,
         private formBuilder: FormBuilder,
         private authService: AuthService,
@@ -85,8 +88,17 @@ export class LoginComponent implements OnInit {
 
             this.appRouter.navigateToHomePage();
             this.loggingIn = false;
-        }, err => {
-            this.tokenInput.setErrors({error: 'Invalid token'});
+        }, (err: HttpErrorResponse) => {
+            if (err.status === 0) {
+                this.alertService.danger('Unable to connect to server');
+            } else if (err.status > 499) {
+                this.alertService.danger('Server error occurred');
+            } else if (err.status === 400) {
+                this.tokenInput.setErrors({error: 'Invalid token'});
+            } else {
+                this.alertService.danger('Unknown error');
+            }
+
             this.loggingIn = false;
         });
     }


### PR DESCRIPTION
Before, any error was shown as the token being wrong. Now, additional errors are displayed accordingly.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#895

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
