### PR TITLE
feat: improve file download speeds for filesyncer

### DIFF
--- a/src/app/files/WorkflowFileApiWrapper.ts
+++ b/src/app/files/WorkflowFileApiWrapper.ts
@@ -13,7 +13,7 @@ export class WorkflowFileApiWrapper implements FileApi {
         return this.workflowService.listFiles(this.namespace, this.uid, path);
     }
 
-    getContent(path: string): Observable<ArtifactResponse> {
+    getContent(path: string): Observable<ArtifactResponse|string> {
         return this.workflowService.getArtifact(this.namespace, this.uid, path);
     }
 }

--- a/src/app/files/file-api.ts
+++ b/src/app/files/file-api.ts
@@ -1,10 +1,10 @@
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
 import { ArtifactResponse, ListFilesResponse } from '../../api';
 
 export interface FileApi {
     listFiles(path: string): Observable<ListFilesResponse>;
-    getContent(path: string): Observable<ArtifactResponse>;
+    getContent(path: string): Observable<ArtifactResponse|string>;
 }
 
 export class FileSyncerFileApi implements FileApi {
@@ -34,13 +34,13 @@ export class FileSyncerFileApi implements FileApi {
         return this.getRequest(url);
     }
 
-    public getContent(path: string): Observable<ArtifactResponse> {
+    public getContent(path: string): Observable<ArtifactResponse|string> {
         if (!path.startsWith('/')) {
             path = '/' + path;
         }
 
         const url = `${this.baseUrl}/api/files/content?path=${path}`;
 
-        return this.getRequest(url);
+        return of(url);
     }
 }

--- a/src/app/files/file-browser-dialog/file-browser-dialog.component.ts
+++ b/src/app/files/file-browser-dialog/file-browser-dialog.component.ts
@@ -92,10 +92,15 @@ export class FileBrowserDialogComponent implements OnInit {
             });
         }
 
+        let i = 0;
         for (const part of parts) {
             const clickable = parts.length > 1 || this.preParts.length > 0;
 
-            pathSum += '/' + part;
+            if (i !== 0) {
+                pathSum += '/';
+            }
+
+            pathSum += part;
 
             pathParts.push({
                 display: part,
@@ -103,6 +108,8 @@ export class FileBrowserDialogComponent implements OnInit {
                 partialPath: pathSum,
                 clickable,
             });
+
+            i++;
         }
 
         const lastPathPart = pathParts[pathParts.length - 1];

--- a/src/app/files/file-browser/file-browser.component.ts
+++ b/src/app/files/file-browser/file-browser.component.ts
@@ -182,18 +182,21 @@ export class FileBrowserComponent implements OnInit, OnDestroy {
       throw new Error('Unable to download a directory');
     }
 
-    // this.workflowService.getArtifact(this.namespace, this.name, file.path)
     this.fileNavigator.getFileContent(file.path)
-        .subscribe((res: any) => {
+        .subscribe((res) => {
           const link = document.createElement('a') as HTMLAnchorElement;
           let downloadName = file.name;
-          if (file.extension) {
+          if (file.name.indexOf('.') === -1 && file.extension) {
             downloadName += `.${file.extension}`;
           }
 
           link.download = downloadName;
 
-          link.href = 'data:application/octet-stream;charset=utf-16le;base64,' + res.data;
+          if (typeof res === 'string' ) {
+            link.href = res;
+          } else {
+            link.href = 'data:application/octet-stream;charset=utf-16le;base64,' + res.data;
+          }
 
           document.body.appendChild(link);
           link.click();

--- a/src/app/files/file-viewer/image-file-view/image-file-view.component.ts
+++ b/src/app/files/file-viewer/image-file-view/image-file-view.component.ts
@@ -23,7 +23,11 @@ export class ImageFileViewComponent implements OnInit {
     if (this.fileApi) {
       this.fileApi.getContent(this.file.path)
           .subscribe(res => {
-            this.setBase64Content(res.data);
+            if (typeof res === 'string' ) {
+              this.setLinkContent(res);
+            } else {
+              this.setBase64Content(res.data);
+            }
           }, err => {
             console.error(err);
           }, () => {
@@ -42,6 +46,10 @@ export class ImageFileViewComponent implements OnInit {
 
   public static IsImageExtension(extension: string){
     return (/(gif|jpg|jpeg|tiff|png)$/i).test(extension);
+  }
+
+  private setLinkContent(url: string) {
+    this.displayContent = url;
   }
 
   private setBase64Content(content: any) {

--- a/src/app/files/file-viewer/text-file-view/text-file-view.component.ts
+++ b/src/app/files/file-viewer/text-file-view/text-file-view.component.ts
@@ -43,7 +43,11 @@ export class TextFileViewComponent implements OnInit {
     if (this.fileApi) {
       this.fileApi.getContent(this.file.path)
           .subscribe(res => {
-            this.setBase64Content(res.data);
+            if (typeof res === 'string' ) {
+              this.displayContent = res;
+            } else {
+              this.setBase64Content(res.data);
+            }
           }, err => {
             console.error(err);
           }, () => {


### PR DESCRIPTION
Also fixes the following bugs
* downloaded files repeated extension twice
* navigation through breadcrumbs sometimes failed

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
