### PR TITLE
fix: added handling for failed state

### DIFF
--- a/src/app/pipes/workspace-phase-image/workspace-phase-image.pipe.ts
+++ b/src/app/pipes/workspace-phase-image/workspace-phase-image.pipe.ts
@@ -19,6 +19,7 @@ export class WorkspacePhaseImagePipe implements PipeTransform {
     ['Paused', WorkspacePhaseImagePipe.pausedImageSource],
     ['Terminating', WorkspacePhaseImagePipe.terminatingImageSource],
     ['Terminated', WorkspacePhaseImagePipe.terminatedSource],
+    ['Failed', WorkspacePhaseImagePipe.terminatedSource],
     ['Failed to pause', WorkspacePhaseImagePipe.terminatedSource],
     ['Failed to resume', WorkspacePhaseImagePipe.terminatedSource],
     ['Failed to terminate', WorkspacePhaseImagePipe.terminatedSource],

--- a/src/app/workspace/workspace-phase-status/workspace-phase-status.pipe.ts
+++ b/src/app/workspace/workspace-phase-status/workspace-phase-status.pipe.ts
@@ -6,6 +6,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class WorkspacePhaseStatusPipe implements PipeTransform {
   static mapping = new Map<string, string>([
       ['Launching', 'Launching...'],
+      ['Failed', 'Failed'],
       ['Failed to launch', 'Failed to launch'],
       ['Failed to resume', 'Failed to resume'],
       ['Updating', 'Updating...'],


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

To reproduce this before this fix, create the default nginx template, but don't provide any slack environment variables.
The workspace status icon/state in the listing page will display an error.

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   
